### PR TITLE
Fix 'realized' computation which was not accounting sells

### DIFF
--- a/inc/tx.php
+++ b/inc/tx.php
@@ -116,7 +116,7 @@ function iterate_tx(array $pf, $start, $end, $interval = '+1 day') {
 				$totals['in'] += $in;
 				$dtotals['in'] += $in;
 			} else if($tx['buy'] < 0) {
-				$out = -$tx['buy'] * $agg[$tkr]['in'] / $agg[$tkr]['qty'];
+				$out = -$tx['buy'] * (($agg[$tkr]['in'] - $agg[$tkr]['out']) / $agg[$tkr]['qty']);
 				$realized = -$tx['buy'] * $tx['price'] - $out;
 
 				$agg[$tkr]['out'] += $out;


### PR DESCRIPTION
I'm not sure it's the perfect way to handle sells, but at least for now I get the expected values for lines with multiple buy / sell (selling everything each time).
